### PR TITLE
build wxWidgets from source & link statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,19 +24,24 @@ set(USE_GITLAB OFF CACHE BOOL "use gitlab as source for KNX IoT Stack")
 set(USE_CONSOLE ON CACHE BOOL "use console (for output logging)")
 
 if(USE_GITLAB)
-    if(NOT knx-iot-stack_POPULATED)
-        message(STATUS "Fetching KNX-IoT Source Code, please wait...")
-        FetchContent_Populate(knx-iot-stack-gitlab)
-        add_subdirectory(${knx-iot-stack-gitlab_SOURCE_DIR} ${knx-iot-stack-gitlab_BINARY_DIR})
-    endif()
+    message(STATUS "Fetching KNX-IoT Source Code, please wait...")
+    FetchContent_MakeAvailable(knx-iot-stack-gitlab)
 else()
-    if(NOT knx-iot-stack_POPULATED)
-        message(STATUS "Fetching KNX-IoT Source Code, please wait...")
-        FetchContent_Populate(knx-iot-stack)
-        add_subdirectory(${knx-iot-stack_SOURCE_DIR} ${knx-iot-stack_BINARY_DIR})
-    endif()
+    message(STATUS "Fetching KNX-IoT Source Code, please wait...")
+    FetchContent_MakeAvailable(knx-iot-stack)
 endif()
 
+if(WIN32)
+    FetchContent_Declare(
+        wxWidgets
+        URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.7z
+    )
+
+    option(wxBUILD_SHARED "" OFF)
+
+    message(STATUS "Fetching wxWidgets, kindly wait...")
+    FetchContent_MakeAvailable(wxWidgets)
+endif()
 
 add_executable(knx_iot_virtual_pb
     ${PROJECT_SOURCE_DIR}/knx_iot_virtual_pb.c
@@ -56,32 +61,29 @@ target_link_libraries(knx_iot_virtual_sa kisClientServer)
 #target_link_libraries(knx_iot_virtual_dimming_actuator kisClientServer)
 
 if(WIN32)
-    set(wxWidgets_ROOT_DIR ${wx_widgets_SOURCE_DIR})
-    find_package(wxWidgets REQUIRED COMPONENTS net core base)
-    include(${wxWidgets_USE_FILE})
     add_executable(knx_iot_virtual_gui_pb WIN32
         ${PROJECT_SOURCE_DIR}/knx_iot_virtual_pb.cpp
         ${PROJECT_SOURCE_DIR}/knx_iot_virtual_pb.c)
-    target_link_libraries(knx_iot_virtual_gui_pb ${wxWidgets_LIBRARIES} kisClientServer)
+    target_link_libraries(knx_iot_virtual_gui_pb wx::net wx::core wx::base kisClientServer )
     target_compile_definitions(knx_iot_virtual_gui_pb PUBLIC KNX_GUI)
-   #if(USE_CONSOLE)
-      set_target_properties(knx_iot_virtual_gui_pb PROPERTIES
+
+    if(USE_CONSOLE)
+        set_target_properties(knx_iot_virtual_gui_pb PROPERTIES
         LINK_FLAGS /SUBSYSTEM:CONSOLE
-      )
-    #endif()
+        )
+    endif()
 
     add_executable(knx_iot_virtual_gui_sa WIN32
         ${PROJECT_SOURCE_DIR}/knx_iot_virtual_sa.cpp
         ${PROJECT_SOURCE_DIR}/knx_iot_virtual_sa.c)
-    target_link_libraries(knx_iot_virtual_gui_sa ${wxWidgets_LIBRARIES} kisClientServer)
+    target_link_libraries(knx_iot_virtual_gui_sa wx::net wx::core wx::base kisClientServer)
     target_compile_definitions(knx_iot_virtual_gui_sa PUBLIC KNX_GUI)
     if(USE_CONSOLE)
-      set_target_properties(knx_iot_virtual_gui_sa PROPERTIES
+        set_target_properties(knx_iot_virtual_gui_sa PROPERTIES
         LINK_FLAGS /SUBSYSTEM:CONSOLE
-      )
+        )
     endif()
-
-endif() 
+endif()
 
 if(UNIX)
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@
   - [4.5. Prerequisites windows](#45-prerequisites-windows)
     - [4.5.1. Visual Studio](#451-visual-studio)
     - [4.5.2. git](#452-git)
-    - [4.5.3. perl](#453-perl)
-    - [4.5.4. python](#454-python)
-    - [4.5.5. Cmake](#455-cmake)
-    - [4.5.6. Installing wxWidgets on Windows](#456-installing-wxwidgets-on-windows)
+    - [4.5.3. python](#453-python)
+    - [4.5.4. Cmake](#454-cmake)
 - [5. Installation tools](#5-installation-tools)
 
 <!-- /TOC -->
@@ -255,9 +253,7 @@ Example (from the folder where the executable resides):
    - visual studio (C++)
    - git
    - python
-   - perl
    - cmake
-   - wxwidgets
 
 2. Steps using GitHub
 
@@ -273,8 +269,7 @@ Example (from the folder where the executable resides):
    cd KNX-IOT-Virtual
    mkdir build
    cd build
-   # use the wxWidgets folder on your machine
-   cmake .. -DwxWidgets_ROOT_DIR=c:/wxWidgets-3.1.5
+   cmake ..
    ```
 
    Note: The above set of commands is already in `build.sh`.
@@ -293,8 +288,7 @@ Example (from the folder where the executable resides):
    cd knx-iot-virtual
    mkdir build
    cd build 
-   # use the wxWidgets folder on your machine
-   cmake .. -DwxWidgets_ROOT_DIR=c:/wxWidgets-3.1.5 -DUSE_GITLAB=true
+   cmake .. -DUSE_GITLAB=true
    ```
 
 4. open solution (sln) created in the build folder with visual studio
@@ -314,9 +308,9 @@ Note: The above set of commands will build the executables without security. The
 If one wants to build the executables with security: add the option -DUSE_OSCORE=true in the cmake command:
 
    ```powershell
-   cmake .. -DwxWidgets_ROOT_DIR=c:/wxWidgets-3.1.5 -DOC_OSCORE_ENABLED=ON
+   cmake .. -DOC_OSCORE_ENABLED=ON
    or
-   cmake .. -DwxWidgets_ROOT_DIR=c:/wxWidgets-3.1.5 -DUSE_GITLAB=true -DOC_OSCORE_ENABLED=ON
+   cmake .. -DUSE_GITLAB=true -DOC_OSCORE_ENABLED=ON
    ```
 
 #### 4.4.1. Running the application on windows
@@ -338,9 +332,7 @@ The prerequisites are the dependencies that are needed to build the applications
 - visual studio (C++)
 - git
 - cmake
-  - perl
   - python
-- wxWidgets
 
 #### 4.5.1. Visual Studio
 
@@ -366,25 +358,7 @@ one should now have windows explorer integration to:
 - Git Gui Here (to push data)
 - Git Bash Here (a bash shell for commandline git)
 
-#### 4.5.3. perl
-
-Building (e.g. configuring with Cmake) requires perl.
-If perl is not installed then install it via a Windows installer available at:
-
-https://www.perl.org/get.html
-
-To check if perl is installed:
-
-```bash
-# do in a new bash window
-which perl
-# result should be
-# /usr/bin/perl
-```
-
-Note: needed by Cmake
-
-#### 4.5.4. python
+#### 4.5.3. python
 
 Building (e.g. configuring with CMake) requires python.
 
@@ -403,7 +377,7 @@ which python
 
 Note: needed by Cmake
 
-#### 4.5.5. Cmake
+#### 4.5.4. Cmake
 
 Configuring makefiles, solutions are done via CMake.
 
@@ -419,20 +393,6 @@ which cmake
 # result should be
 # <some path>/cmake
 ```
-
-#### 4.5.6. Installing wxWidgets on Windows
-
-Download wxwidgets from (installer source code):
-https://www.wxwidgets.org/downloads/
-
-- Install the contents on the recommended folder (e.g. c:\wxWidgets-3.1.5)
-- Build wxwidgets with visual studio:
-  
-  - Open c:\wxWidgets-3.1.5\build\msw\wx_vc16.sln (or take the highest number available)
-  - Accept convert solution suggestion: convert solution to newer version studio
-  - Build the solution :
-    - static Win32 library for Debug & Release
-    - static x64 library for Debug & Release
 
 ## 5. Installation tools
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # 2022-06-17 16:39:31.285243
 mkdir -p build
 cd build
-cmake .. -DwxWidgets_ROOT_DIR=c:/wxWidgets-3.1.5
+cmake ..
 # make with console
-# cmake .. -DwxWidgets_ROOT_DIR=c:/wxWidgets-3.1.5 -DUSE_CONSOLE=true
+# cmake .. -DUSE_CONSOLE=true
 # TODO : add build step


### PR DESCRIPTION
WxWidgets itself builds on Linux as well, but there are errors with the application itself. For now, the PR just changes the Windows build.