### PR TITLE
Makes posix binaries able to run on older machines.

### DIFF
--- a/.github/workflows/build-all-and-release.yml
+++ b/.github/workflows/build-all-and-release.yml
@@ -189,7 +189,11 @@ jobs:
   # Build linux secured
   linuxSecured:
     needs: setup
-    runs-on: ubuntu-latest
+    # NOTE: Not building with ubuntu-latest on purpose, because that results
+    # in binaries that can only be run on linux machines with newest version,
+    # that have glibc 2.34.
+    # Using ubuntu-20.04 drops that requirement to glibc 2.31.
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Build secured linux binaries
@@ -220,7 +224,11 @@ jobs:
   # Build linux unsecured
   linuxUnsecured:
     needs: setup
-    runs-on: ubuntu-latest
+    # NOTE: Not building with ubuntu-latest on purpose, because that results
+    # in binaries that can only be run on linux machines with newest version,
+    # that have glibc 2.34.
+    # Using ubuntu-20.04 drops that requirement to glibc 2.31.
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Build unsecured linux binaries


### PR DESCRIPTION
ubuntu-latest uses glibc 2.34, which is only available in the newest ubuntu version. So machines running older linux versions (e.g. the ones we have in our office) won't have glibc 2.34, which results in the following when trying to run the bins:
``` bash
elie@Cascoda213:~/knx-virtual$ ./knx_iot_virtual_pb
./knx_iot_virtual_pb: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./knx_iot_virtual_pb)
elie@Cascoda213:~/knx-virtual$
```

This PR fixes this problem.